### PR TITLE
Removed windows dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "@digitalpersona/devices",
   "globalObject": "dp.devices",
   "version": "0.2.4",
-  "os": [
-    "win32"
-  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/hidglobal/digitalpersona-devices"


### PR DESCRIPTION
Windows should not be required as it's not required to run windows to build it or to host scripts. 